### PR TITLE
Install media directory

### DIFF
--- a/ubuntu/debian/libgz-sim.install
+++ b/ubuntu/debian/libgz-sim.install
@@ -2,5 +2,6 @@ usr/lib/*/*.so.*
 usr/share/*/*-*[0-99]/*.config
 usr/share/*/*-*[0-99]/gui/*
 usr/share/*/*-*[0-99]/worlds/*
+usr/share/*/*-*[0-99]/media/*
 obj-*/gz-logo[0-99].svg usr/share/icons/hicolor/scalable/apps/
 obj-*/gz-sim[0-99].desktop usr/share/applications/


### PR DESCRIPTION
https://github.com/gazebosim/gz-sim/pull/2269 adds files to `usr/share/gz/gz-sim8/media`.

This should fix the warning on https://build.osrfoundation.org/job/gz-sim8-debbuilder/548/
```
dh_missing: warning: usr/share/gz/gz-sim8/media/gazebo.material exists in debian/tmp but is not installed to anywhere 
	The following debhelper tools have reported what they installed (with files per package)
	 * dh_install: gz-sim8-cli (6), libgz-sim8 (271), libgz-sim8-dbg (0), libgz-sim8-dev (436), libgz-sim8-plugins (273), python3-gz-sim8 (1)
	 * dh_installdocs: gz-sim8-cli (0), libgz-sim8 (0), libgz-sim8-dbg (0), libgz-sim8-dev (0), libgz-sim8-plugins (0), python3-gz-sim8 (0)
	If the missing files are installed by another tool, please file a bug against it.
	When filing the report, if the tool is not part of debhelper itself, please reference the
	"Logging helpers and dh_missing" section from the "PROGRAMMING" guide for debhelper (10.6.3+).
	  (in the debhelper package: /usr/share/doc/debhelper/PROGRAMMING.gz)
	Be sure to test with dpkg-buildpackage -A/-B as the results may vary when only a subset is built
	If the omission is intentional or no other helper can take care of this consider adding the
	paths to debian/not-installed.
   dh_dwz
```